### PR TITLE
Preserve client metadata

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -13,3 +13,4 @@ jobs:
       python_versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
       install_extras: 'test'
       test_path: 'test'
+      pr_comment: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,3 +15,4 @@ jobs:
       test_path: 'test/'
       install_extras: 'test'
       min_coverage: 80
+      pr_comment: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -9,3 +9,5 @@ jobs:
   license_check:
     uses: OpenVoiceOS/gh-automations/.github/workflows/license-check.yml@dev
     secrets: inherit
+    with:
+      pr_comment: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,3 +12,4 @@ jobs:
     with:
       ruff: true
       pre_commit: false   # set true if .pre-commit-config.yaml exists
+      pr_comment: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/pip_audit.yml
+++ b/.github/workflows/pip_audit.yml
@@ -9,3 +9,5 @@ jobs:
   pip_audit:
     uses: OpenVoiceOS/gh-automations/.github/workflows/pip-audit.yml@dev
     secrets: inherit
+    with:
+      pr_comment: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   release_preview:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     uses: OpenVoiceOS/gh-automations/.github/workflows/release-preview.yml@dev
     secrets: inherit
     with:

--- a/.github/workflows/repo-health.yml
+++ b/.github/workflows/repo-health.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   repo_health:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     uses: OpenVoiceOS/gh-automations/.github/workflows/repo-health.yml@dev
     secrets: inherit
     with:

--- a/json_database/hpm.py
+++ b/json_database/hpm.py
@@ -3,7 +3,10 @@ from ovos_utils.log import LOG
 from ovos_utils.xdg_utils import xdg_data_home
 from typing import Union, Iterable, List, Optional
 from json_database import JsonStorageXDG, EncryptedJsonStorageXDG
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
+
+
+CLIENT_SUPPORTS_METADATA = any(field.name == "metadata" for field in fields(Client))
 
 
 @dataclass
@@ -39,7 +42,12 @@ class JsonDB(AbstractDB):
         Returns:
             True if the addition was successful, False otherwise.
         """
-        self._db[client.client_id] = client.__dict__
+        client_data = dict(client.__dict__)
+        if not CLIENT_SUPPORTS_METADATA:
+            client_data.pop("metadata", None)
+        elif not isinstance(client_data.get("metadata"), dict):
+            client_data["metadata"] = {}
+        self._db[client.client_id] = client_data
         return True
 
     def search_by_value(self, key: str, val: Union[str, bool, int, float]) -> List[Client]:
@@ -57,12 +65,12 @@ class JsonDB(AbstractDB):
         if key == "client_id":
             v = self._db.get(val)
             if v:
-                res.append(cast2client(v))
+                res.append(self._cast_client(v))
         else:
             for client in self._db.values():
                 v = client.get(key)
                 if v == val:
-                    res.append(cast2client(client))
+                    res.append(self._cast_client(client))
         return res
 
     def __len__(self) -> int:
@@ -82,7 +90,7 @@ class JsonDB(AbstractDB):
             An iterator over the clients in the database.
         """
         for item in self._db.values():
-            yield Client.deserialize(item)
+            yield self._cast_client(item)
 
     def commit(self) -> bool:
         """
@@ -97,3 +105,14 @@ class JsonDB(AbstractDB):
         except Exception as e:
             LOG.error(f"Failed to save {self._db.path} - {e}")
             return False
+
+    @staticmethod
+    def _cast_client(client_data) -> Client:
+        if not CLIENT_SUPPORTS_METADATA and isinstance(client_data, dict):
+            client_data = dict(client_data)
+            client_data.pop("metadata", None)
+        elif CLIENT_SUPPORTS_METADATA and isinstance(client_data, dict):
+            if not isinstance(client_data.get("metadata"), dict):
+                client_data = dict(client_data)
+                client_data["metadata"] = {}
+        return cast2client(client_data)

--- a/test/test_hpm.py
+++ b/test/test_hpm.py
@@ -3,6 +3,7 @@ from dataclasses import fields
 
 from hivemind_plugin_manager.database import Client
 
+import json_database.hpm as hpm
 from json_database.hpm import JsonDB
 
 
@@ -10,13 +11,14 @@ CLIENT_SUPPORTS_METADATA = any(field.name == "metadata" for field in fields(Clie
 METADATA_SUPPORT_REQUIRED = "Client.metadata requires hivemind-plugin-manager metadata support"
 
 
-def make_db() -> JsonDB:
-    db = object.__new__(JsonDB)
-    db._db = {}
-    return db
+def make_db(tmp_path, monkeypatch) -> JsonDB:
+    """Return an initialized JsonDB backed by a temp XDG data path."""
+    monkeypatch.setattr(hpm, "xdg_data_home", lambda: str(tmp_path))
+    return JsonDB()
 
 
 def make_client(*, metadata=None, **kwargs) -> Client:
+    """Build a Client while staying compatible with older client models."""
     client = Client(**kwargs)
     if metadata is not None:
         client.metadata = metadata
@@ -24,8 +26,9 @@ def make_client(*, metadata=None, **kwargs) -> Client:
 
 
 @pytest.mark.skipif(not CLIENT_SUPPORTS_METADATA, reason=METADATA_SUPPORT_REQUIRED)
-def test_hivemind_client_metadata_survives_search_round_trip():
-    db = make_db()
+def test_hivemind_client_metadata_survives_search_round_trip(tmp_path, monkeypatch):
+    """Client metadata survives add and search in JsonDB."""
+    db = make_db(tmp_path, monkeypatch)
     client = make_client(
         client_id=1,
         api_key="alpha-key",
@@ -41,8 +44,9 @@ def test_hivemind_client_metadata_survives_search_round_trip():
 
 
 @pytest.mark.skipif(not CLIENT_SUPPORTS_METADATA, reason=METADATA_SUPPORT_REQUIRED)
-def test_hivemind_client_metadata_survives_iteration():
-    db = make_db()
+def test_hivemind_client_metadata_survives_iteration(tmp_path, monkeypatch):
+    """Client metadata survives iteration in JsonDB."""
+    db = make_db(tmp_path, monkeypatch)
     client = make_client(
         client_id=1,
         api_key="alpha-key",
@@ -57,8 +61,9 @@ def test_hivemind_client_metadata_survives_iteration():
     assert found[0].metadata == {"owner_id": "owner-123"}
 
 
-def test_hivemind_client_metadata_record_does_not_break_old_client_model():
-    db = make_db()
+def test_hivemind_client_metadata_record_does_not_break_old_client_model(tmp_path, monkeypatch):
+    """Stored metadata does not break older Client models."""
+    db = make_db(tmp_path, monkeypatch)
     db._db[1] = {
         "client_id": 1,
         "api_key": "alpha-key",

--- a/test/test_hpm.py
+++ b/test/test_hpm.py
@@ -1,0 +1,76 @@
+import pytest
+from dataclasses import fields
+
+from hivemind_plugin_manager.database import Client
+
+from json_database.hpm import JsonDB
+
+
+CLIENT_SUPPORTS_METADATA = any(field.name == "metadata" for field in fields(Client))
+METADATA_SUPPORT_REQUIRED = "Client.metadata requires hivemind-plugin-manager metadata support"
+
+
+def make_db() -> JsonDB:
+    db = object.__new__(JsonDB)
+    db._db = {}
+    return db
+
+
+def make_client(*, metadata=None, **kwargs) -> Client:
+    client = Client(**kwargs)
+    if metadata is not None:
+        client.metadata = metadata
+    return client
+
+
+@pytest.mark.skipif(not CLIENT_SUPPORTS_METADATA, reason=METADATA_SUPPORT_REQUIRED)
+def test_hivemind_client_metadata_survives_search_round_trip():
+    db = make_db()
+    client = make_client(
+        client_id=1,
+        api_key="alpha-key",
+        name="alpha",
+        metadata={"owner_id": "owner-123"},
+    )
+
+    assert db.add_item(client)
+    found = db.search_by_value("api_key", "alpha-key")
+
+    assert len(found) == 1
+    assert found[0].metadata == {"owner_id": "owner-123"}
+
+
+@pytest.mark.skipif(not CLIENT_SUPPORTS_METADATA, reason=METADATA_SUPPORT_REQUIRED)
+def test_hivemind_client_metadata_survives_iteration():
+    db = make_db()
+    client = make_client(
+        client_id=1,
+        api_key="alpha-key",
+        name="alpha",
+        metadata={"owner_id": "owner-123"},
+    )
+
+    assert db.add_item(client)
+    found = list(db)
+
+    assert len(found) == 1
+    assert found[0].metadata == {"owner_id": "owner-123"}
+
+
+def test_hivemind_client_metadata_record_does_not_break_old_client_model():
+    db = make_db()
+    db._db[1] = {
+        "client_id": 1,
+        "api_key": "alpha-key",
+        "name": "alpha",
+        "metadata": {"owner_id": "owner-123"},
+    }
+
+    found = db.search_by_value("api_key", "alpha-key")
+
+    assert len(found) == 1
+    assert found[0].api_key == "alpha-key"
+    if CLIENT_SUPPORTS_METADATA:
+        assert found[0].metadata == {"owner_id": "owner-123"}
+    else:
+        assert not hasattr(found[0], "metadata")


### PR DESCRIPTION
Adds coverage for the HiveMind JSON DB plugin to make sure `Client.metadata` survives search and iteration.

Needs client metadata support in JarbasHiveMind/hivemind-plugin-manager#21.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for client metadata persistence across database operations to ensure data integrity and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TigreGotico/json_database/pull/25?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->