### PR TITLE
ci: pass PYPI_TOKEN explicitly, drop secrets:inherit elsewhere

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   build:
     uses: OpenVoiceOS/gh-automations/.github/workflows/build-tests.yml@dev
-    secrets: inherit
     with:
       python_versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
       install_extras: 'test'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   coverage:
     uses: OpenVoiceOS/gh-automations/.github/workflows/coverage.yml@dev
-    secrets: inherit
     with:
       python_version: '3.11'
       coverage_source: 'json_database'

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -8,6 +8,5 @@ on:
 jobs:
   license_check:
     uses: OpenVoiceOS/gh-automations/.github/workflows/license-check.yml@dev
-    secrets: inherit
     with:
       pr_comment: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   lint:
     uses: OpenVoiceOS/gh-automations/.github/workflows/lint.yml@dev
-    secrets: inherit
     with:
       ruff: true
       pre_commit: false   # set true if .pre-commit-config.yaml exists

--- a/.github/workflows/pip_audit.yml
+++ b/.github/workflows/pip_audit.yml
@@ -8,6 +8,5 @@ on:
 jobs:
   pip_audit:
     uses: OpenVoiceOS/gh-automations/.github/workflows/pip-audit.yml@dev
-    secrets: inherit
     with:
       pr_comment: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/publish_stable.yml
+++ b/.github/workflows/publish_stable.yml
@@ -7,7 +7,8 @@ on:
 jobs:
   publish_stable:
     uses: TigreGotico/gh-automations/.github/workflows/publish-stable.yml@master
-    secrets: inherit
+    secrets:
+      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
     with:
       branch: 'master'
       version_file: 'json_database/version.py'

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -9,7 +9,6 @@ jobs:
   release_preview:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     uses: OpenVoiceOS/gh-automations/.github/workflows/release-preview.yml@dev
-    secrets: inherit
     with:
       package_name: 'json_database'
       version_file: 'json_database/version.py'

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -9,7 +9,8 @@ jobs:
   publish_alpha:
     if: github.event.pull_request.merged == true
     uses: TigreGotico/gh-automations/.github/workflows/publish-alpha.yml@master
-    secrets: inherit
+    secrets:
+      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
     with:
       branch: 'dev'
       version_file: 'json_database/version.py'

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -1,13 +1,14 @@
 name: Release Alpha and Propose Stable
 
 on:
+  workflow_dispatch:
   pull_request:
     types: [closed]
     branches: [dev]
 
 jobs:
   publish_alpha:
-    if: github.event.pull_request.merged == true
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     uses: TigreGotico/gh-automations/.github/workflows/publish-alpha.yml@master
     secrets:
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
@@ -20,7 +21,7 @@ jobs:
       changelog_max_issues: 100
 
   notify:
-    if: github.event.pull_request.merged == true
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     needs: publish_alpha
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/repo-health.yml
+++ b/.github/workflows/repo-health.yml
@@ -9,6 +9,5 @@ jobs:
   repo_health:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     uses: OpenVoiceOS/gh-automations/.github/workflows/repo-health.yml@dev
-    secrets: inherit
     with:
       version_file: 'json_database/version.py'


### PR DESCRIPTION
`secrets: inherit` fails when calling `publish-stable.yml`/`publish-alpha.yml` from gh-automations. Drop `inherit` lines from workflows that don't need secrets; pass `PYPI_TOKEN` explicitly on the publish ones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD security by refining credential management across automated workflows. Build, testing, code quality checks, security audits, and deployment processes now use more granular access controls and enhanced handling of sensitive credentials and authentication tokens.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TigreGotico/json_database/pull/28?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->