### PR TITLE
fix: pin hpm back-compat shim to a version that ships the entry point

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ crypto = ["pycryptodomex"]
 # ``hivemind-json-db-plugin`` entry point remains available.
 # This extra will be REMOVED in 2.0.0 — migrate to
 # ``pip install hivemind-json-db-plugin`` directly.
-hpm = ["hivemind-json-db-plugin"]
+hpm = ["hivemind-json-db-plugin>=0.0.3a2"]
 test = [
     "coveralls>=1.8.2",
     "flake8>=3.7.9",


### PR DESCRIPTION
The `json_database[hpm]` back-compat shim re-exposes the extracted plugin via `hivemind-json-db-plugin` but had no version floor. Pin `>=0.0.3a2` so `pip install json_database[hpm]` reliably pulls a build that registers the `hivemind-json-db-plugin` entry point.

**Why now:** `dev` is at `1.0.0a1` with the bundled `hivemind-json-db-plugin` entry point already dropped (#27), but no 1.0.x has published (the May release failed on the old setup.py workflow, since modernized). PyPI's latest is still `0.10.2a1`, which ships the **duplicate** entry point that collides with the standalone plugin. Merging this cuts a 1.0.x alpha, which:
- removes the duplicate-entry-point ambiguity ecosystem-wide, and
- unblocks [hivemind-json-db-plugin#13](https://github.com/JarbasHiveMind/hivemind-json-db-plugin/pull/13) (requires `json_database>=1.0.0a1`; its CI is red only because 1.0.x isn't on PyPI yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the optional `hpm` dependency to enforce a minimum version constraint, ensuring compatibility with the latest features and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->