### PR TITLE
fix: JsonStorage.load_local() wipes data on a transient parse failure

### DIFF
--- a/json_database/__init__.py
+++ b/json_database/__init__.py
@@ -93,15 +93,23 @@ class JsonStorage(dict):
         with self.lock:
             path = expanduser(path)
             if exists(path) and isfile(path):
-                self.clear()
+                # Parse into a scratch dict first. Only replace the current
+                # in-memory contents once parsing succeeds: a concurrent
+                # writer can leave the file transiently truncated/invalid
+                # (a "torn read"), and clearing self before the parse is
+                # known to succeed would permanently discard previously
+                # loaded settings for a purely transient error, with no
+                # way to recover them on a later, successful reload.
                 try:
                     config = load_commented_json(path)
-                    for key in config:
-                        self[key] = config[key]
-                    LOG.debug("Json {} loaded".format(path))
                 except Exception as e:
                     LOG.error("Error loading json '{}'".format(path))
                     LOG.error(repr(e))
+                    return
+                self.clear()
+                for key in config:
+                    self[key] = config[key]
+                LOG.debug("Json {} loaded".format(path))
             else:
                 LOG.debug("Json '{}' not defined, skipping".format(path))
 

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -34,6 +34,27 @@ class TestJsonStorageErrorHandling:
         with pytest.raises(DatabaseNotCommitted):
             storage.reload()
 
+    def test_reload_survives_torn_write_then_recovers(self, tmp_path):
+        """A reload() hitting a transient torn/corrupted write (e.g. an
+        external editor caught mid-save) must not wipe out the last known
+        good settings, and a later valid write must be picked up normally.
+        """
+        db_file = tmp_path / "settings.json"
+        db_file.write_text(json.dumps({"volume": 5}))
+        storage = JsonStorage(str(db_file), disable_lock=True)
+        assert storage["volume"] == 5
+
+        # Simulate a torn read: file caught mid-write, content is invalid.
+        db_file.write_text('{"volume": 9, "unit"')
+        storage.reload()
+        # Previously loaded settings must survive a failed parse.
+        assert storage["volume"] == 5
+
+        # A later, valid write must be reflected normally.
+        db_file.write_text(json.dumps({"volume": 9}))
+        storage.reload()
+        assert storage["volume"] == 9
+
     def test_store_without_path(self, tmp_path):
         """Test store with no path set."""
         storage = JsonStorage("", disable_lock=True)


### PR DESCRIPTION
## What was broken

`JsonStorage.load_local()` called `self.clear()` *before* attempting to
parse the JSON file:

```python
if exists(path) and isfile(path):
    self.clear()
    try:
        config = load_commented_json(path)
        ...
    except Exception as e:
        LOG.error("Error loading json '{}'".format(path))
        LOG.error(repr(e))
```

If `reload()` (or the initial load) hits the file while another process
is mid-write — a "torn read" that yields invalid/partial JSON — the
`JSONDecodeError` is caught and logged, but `self` was already cleared.
The previously loaded settings are permanently lost for what is a purely
transient error, and since the exception is swallowed, no caller ever
sees a failure to trigger a retry.

This was observed with `ovos-workshop`'s skill-settings `FileWatcher`:
editing a skill's `settings.json` externally while `ovos-core` is
running can log `Error loading json '.../settings.json'` (this exact
message), after which `self.settings` in the running skill stops
reflecting the file's contents — the watcher keeps firing but the data
that was wiped by the failed reload is never restored.

## How it fails

Reproduced directly against `JsonStorage`, no core/workshop needed:

1. Load a valid settings file (`{"volume": 5}`).
2. Overwrite the file with a truncated/invalid fragment (simulating a
   torn read: `{"volume": 9, "unit"`).
3. Call `reload()`.
4. `storage["volume"]` raises `KeyError` — the good data is gone, even
   though the bad write was never actually committed as the final file
   state.

## The fix

Parse into a scratch dict first; only `clear()` and repopulate `self`
once parsing succeeds. A transient/torn read now leaves the
previously-loaded data intact (logged, not fatal), and a subsequent
valid write is still picked up normally on the next `reload()`.

## Verification

Added `test_reload_survives_torn_write_then_recovers` to
`test/test_storage.py`, which:
- fails on the pre-fix code (`KeyError`, with the exact
  `Error loading json '...'` log line from the field report), and
- passes with the fix, including confirming a later valid write is
  still correctly reloaded.

Full suite: `392 passed` (`test/`), no regressions.

---
Authored with AI assistance (Claude), verified by running the affected
unit tests and a manual pre/post-fix diff of the new regression test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved previously loaded settings when a local JSON file is temporarily invalid or cannot be read.
  * Allowed storage reloads to recover automatically once the file contains valid JSON again.

* **Tests**
  * Added coverage for failed reloads caused by incomplete writes and successful recovery afterward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->